### PR TITLE
Do not create the inband EPG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1 (unreleased)
+
+- Do not create the inband EPG as it overlaps with the `terraform-aci-inband-endpoint-group` module
+- Remove `endpoint_group_vlan` attribute as it is no longer required by this module 
+
 ## 0.2.0
 
 - BREAKING CHANGE: Add `endpoint_group_vlan` attribute which is required for ACI 6.0+

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ module "aci_inband_node_address" {
   source  = "netascode/inband-node-address/aci"
   version = ">= 0.2.0"
 
-  node_id             = 201
-  pod_id              = 2
-  ip                  = "10.1.1.100/24"
-  gateway             = "10.1.1.254"
-  v6_ip               = "2002::2/64"
-  v6_gateway          = "2002::1"
-  endpoint_group      = "INB1"
-  endpoint_group_vlan = 4
+  node_id        = 201
+  pod_id         = 2
+  ip             = "10.1.1.100/24"
+  gateway        = "10.1.1.254"
+  v6_ip          = "2002::2/64"
+  v6_gateway     = "2002::1"
+  endpoint_group = "INB1"
 }
 ```
 
@@ -50,7 +49,6 @@ module "aci_inband_node_address" {
 | <a name="input_v6_ip"></a> [v6\_ip](#input\_v6\_ip) | Inband IPv6 address. | `string` | `""` | no |
 | <a name="input_v6_gateway"></a> [v6\_gateway](#input\_v6\_gateway) | Inband IPv6 gateway IP. | `string` | `""` | no |
 | <a name="input_endpoint_group"></a> [endpoint\_group](#input\_endpoint\_group) | Inband management endpoint group name. | `string` | n/a | yes |
-| <a name="input_endpoint_group_vlan"></a> [endpoint\_group\_vlan](#input\_endpoint\_group\_vlan) | Inband management endpoint group vlan. | `number` | n/a | yes |
 
 ## Outputs
 
@@ -62,6 +60,5 @@ module "aci_inband_node_address" {
 
 | Name | Type |
 |------|------|
-| [aci_rest.mgmtInB](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest) | resource |
 | [aci_rest_managed.mgmtRsInBStNode](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -16,14 +16,13 @@ module "aci_inband_node_address" {
   source  = "netascode/inband-node-address/aci"
   version = ">= 0.2.0"
 
-  node_id             = 201
-  pod_id              = 2
-  ip                  = "10.1.1.100/24"
-  gateway             = "10.1.1.254"
-  v6_ip               = "2002::2/64"
-  v6_gateway          = "2002::1"
-  endpoint_group      = "INB1"
-  endpoint_group_vlan = 4
+  node_id        = 201
+  pod_id         = 2
+  ip             = "10.1.1.100/24"
+  gateway        = "10.1.1.254"
+  v6_ip          = "2002::2/64"
+  v6_gateway     = "2002::1"
+  endpoint_group = "INB1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,12 +2,11 @@ module "aci_inband_node_address" {
   source  = "netascode/inband-node-address/aci"
   version = ">= 0.2.0"
 
-  node_id             = 201
-  pod_id              = 2
-  ip                  = "10.1.1.100/24"
-  gateway             = "10.1.1.254"
-  v6_ip               = "2002::2/64"
-  v6_gateway          = "2002::1"
-  endpoint_group      = "INB1"
-  endpoint_group_vlan = 4
+  node_id        = 201
+  pod_id         = 2
+  ip             = "10.1.1.100/24"
+  gateway        = "10.1.1.254"
+  v6_ip          = "2002::2/64"
+  v6_gateway     = "2002::1"
+  endpoint_group = "INB1"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,25 +1,3 @@
-# Workaround to create inband EPG in case it does not exist yet, but avoid deleting it when the module is destroyed
-resource "aci_rest" "mgmtInB" {
-  path    = "/api/mo/uni/tn-mgmt/mgmtp-default.json"
-  payload = <<EOF
-    {
-      "mgmtMgmtP": {
-        "attributes": {},
-        "children": [
-          {
-            "mgmtInB": {
-              "attributes": {
-                "name": "${var.endpoint_group}",
-                "encap": "vlan-${var.endpoint_group_vlan}"
-              }
-            }
-          }
-        ]
-      }
-    }
-  EOF
-}
-
 resource "aci_rest_managed" "mgmtRsInBStNode" {
   dn         = "uni/tn-mgmt/mgmtp-default/inb-${var.endpoint_group}/rsinBStNode-[topology/pod-${var.pod_id}/node-${var.node_id}]"
   class_name = "mgmtRsInBStNode"
@@ -30,6 +8,4 @@ resource "aci_rest_managed" "mgmtRsInBStNode" {
     v6Gw   = var.v6_gateway
     tDn    = "topology/pod-${var.pod_id}/node-${var.node_id}"
   }
-
-  depends_on = [aci_rest.mgmtInB]
 }

--- a/tests/full/test_full.tf
+++ b/tests/full/test_full.tf
@@ -16,14 +16,13 @@ terraform {
 module "main" {
   source = "../.."
 
-  node_id             = 201
-  pod_id              = 2
-  ip                  = "10.1.1.100/24"
-  gateway             = "10.1.1.254"
-  v6_ip               = "2002::2/64"
-  v6_gateway          = "2002::1"
-  endpoint_group      = "INB1"
-  endpoint_group_vlan = 104
+  node_id        = 201
+  pod_id         = 2
+  ip             = "10.1.1.100/24"
+  gateway        = "10.1.1.254"
+  v6_ip          = "2002::2/64"
+  v6_gateway     = "2002::1"
+  endpoint_group = "INB1"
 }
 
 data "aci_rest_managed" "mgmtRsInBStNode" {

--- a/tests/minimal/test_minimal.tf
+++ b/tests/minimal/test_minimal.tf
@@ -16,10 +16,9 @@ terraform {
 module "main" {
   source = "../.."
 
-  node_id             = 201
-  pod_id              = 2
-  endpoint_group      = "INB1"
-  endpoint_group_vlan = 104
+  node_id        = 201
+  pod_id         = 2
+  endpoint_group = "INB1"
 }
 
 data "aci_rest_managed" "mgmtRsInBStNode" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,13 +52,3 @@ variable "endpoint_group" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
-
-variable "endpoint_group_vlan" {
-  description = "Inband management endpoint group vlan."
-  type        = number
-
-  validation {
-    condition     = var.endpoint_group_vlan >= 1 && var.endpoint_group_vlan <= 4094
-    error_message = "Minimum value: 1. Maximum value: 4094."
-  }
-}


### PR DESCRIPTION
Do not create the inband EPG as it gets created by the `terraform-aci-inband-endpoint-group` module. The inband EPG should already exist prior to executing this module.

Since we're no longer creating the inband EPG, the `endpoint_group_vlan` attribute is no longer required by this module.